### PR TITLE
Enable model loading for TSC test

### DIFF
--- a/task/task.py
+++ b/task/task.py
@@ -42,7 +42,8 @@ class TSCTask(BaseTask):
             if Registry.mapping['model_mapping']['setting'].param['train_model']:
                 self.trainer.train()
             if Registry.mapping['model_mapping']['setting'].param['test_model']:
-                self.trainer.test()
+                drop_load = not Registry.mapping['model_mapping']['setting'].param["load_model"]
+                self.trainer.test(drop_load=drop_load)
         except RuntimeError as e:
             self._process_error(e)
             raise e


### PR DESCRIPTION
When testing a trained model, One should be able to load the 'state_dict' saved after training.