### PR TITLE
Fix agents

### DIFF
--- a/agent/frap.py
+++ b/agent/frap.py
@@ -138,7 +138,7 @@ class FRAP_DQNAgent(RLAgent):
         '''
         comp_mask = []
         for i in range(len(self.phase_pairs)):
-            zeros = np.zeros(len(self.phase_pairs) - 1, dtype=np.int)
+            zeros = np.zeros(len(self.phase_pairs) - 1, dtype=np.int64)
             cnt = 0
             for j in range(len(self.phase_pairs)):
                 if i == j: continue

--- a/agent/mplight.py
+++ b/agent/mplight.py
@@ -300,7 +300,7 @@ class MPLightAgent(RLAgent):
             queue.append((self.queue[i][1].generate()))
         maxsize = max(len(x) for x in queue)
         for i in range(len(queue)):
-            queue[i] = np.resize(queue[i], maxsize)
+            queue[i] = np.pad(queue[i], (0, maxsize - queue[i].shape[-1]))
         tmp_queue = np.squeeze(np.array(queue))
         if self.sub_agents == 1:
             queue = np.sum(tmp_queue)

--- a/agent/mplight.py
+++ b/agent/mplight.py
@@ -215,7 +215,7 @@ class MPLightAgent(RLAgent):
         '''
         comp_mask = []
         for i in range(len(self.phase_pairs)):
-            zeros = np.zeros(len(self.phase_pairs) - 1, dtype=np.int)
+            zeros = np.zeros(len(self.phase_pairs) - 1, dtype=np.int64)
             cnt = 0
             for j in range(len(self.phase_pairs)):
                 if i == j: continue
@@ -298,6 +298,9 @@ class MPLightAgent(RLAgent):
         queue = []
         for i in range(len(self.queue)):
             queue.append((self.queue[i][1].generate()))
+        maxsize = max(len(x) for x in queue)
+        for i in range(len(queue)):
+            queue[i] = np.resize(queue[i], maxsize)
         tmp_queue = np.squeeze(np.array(queue))
         if self.sub_agents == 1:
             queue = np.sum(tmp_queue)

--- a/common/interface.py
+++ b/common/interface.py
@@ -1,4 +1,4 @@
-from common.utils import build_index_intersection_map
+from common.utils import build_index_intersection_map_cityflow, build_index_intersection_map_sumo
 from common.registry import Registry
 from utils.logger import load_config_dict, modify_config_file, get_output_file_path
 import os
@@ -26,7 +26,11 @@ class Graph_World_Interface(Interface):
     def __init__(self, path):
         super(Graph_World_Interface, self).__init__()
         # TODO: support other roadnet file formation other than cityflow
-        Graph_World_Interface.graph = build_index_intersection_map(path)
+        world = Registry.mapping['command_mapping']['setting'].param['world']
+        if world == "cityflow":
+            Graph_World_Interface.graph = build_index_intersection_map_cityflow(path)
+        elif world == "sumo":
+            Graph_World_Interface.graph = build_index_intersection_map_sumo(path)
 
 
 @Registry.register_world('setting')

--- a/common/utils.py
+++ b/common/utils.py
@@ -128,11 +128,14 @@ def build_index_intersection_map_sumo(roadnet_file):
     edge_list = []  # adjacent node of each node
     node_list = []  # adjacent edge of each node
     sparse_adj = []  # adjacent node of each edge
-
+    
+    def get_node_id(node):
+        node_id = node.getID()
+        return node_id if 'GS_' not in node_id else node_id[3:]
     # build the map between identity and index of node
     cur_num = 0
     for tl in net.getTrafficLights():
-        cur_id = tl.getID()
+        cur_id = get_node_id(tl)
         node_idx2id[cur_num] = cur_id
         node_id2idx[cur_id] = cur_num
         cur_num += 1
@@ -142,8 +145,8 @@ def build_index_intersection_map_sumo(roadnet_file):
     cur_num = 0
     for edge in net.getEdges():
         edge_id = edge.getID()
-        input_node_id = edge.getFromNode().getID()
-        output_node_id = edge.getToNode().getID()
+        input_node_id = get_node_id(edge.getFromNode())
+        output_node_id = get_node_id(edge.getToNode())
         # skip edges where there are no traffic lights
         if input_node_id not in node_id2idx.keys() or output_node_id not in node_id2idx.keys():
             continue
@@ -158,20 +161,20 @@ def build_index_intersection_map_sumo(roadnet_file):
     # build adjacent matrix for node (i.e the adjacent node of the node, and the 
         # adjacent edge of the node)
     for tl in net.getTrafficLights():
-        node_id = tl.getID()
+        node_id = get_node_id(tl) 
         road_links = tl.getEdges()
         input_nodes = []  # should be node_degree
         input_edges = []  # needed, should be node_degree
         for road_link in road_links:
             road_link_id = road_link.getID()
-            end_intersection = road_link.getToNode().getID()
+            end_intersection = get_node_id(road_link.getToNode())
             if end_intersection == node_id:
                 if road_link_id in edge_id2idx.keys():
                     input_edge_idx = edge_id2idx[road_link_id]
                     input_edges.append(input_edge_idx)
                 else:
                     continue
-                start_node = road_link.getFromNode().getID()
+                start_node = get_node_id(road_link.getFromNode())
                 if start_node in node_id2idx.keys():
                     start_node_idx = node_id2idx[start_node]
                     input_nodes.append(start_node_idx)


### PR DESCRIPTION
Some of the rl agents were not working(`frap`, `mplight`, `colight`, `ppo`, `magd` were not working when I tested). I made some adjustmens to make `frap`, `mplight` and `colight` work for now.

For `frap` and `mplight`, in newer versions of numpy, there is a deprecation error when using `np.int`. They now use `np.int64` instead. `mplight` used to give errors when using networks with irregular lane numbers(like `cologne3`), it now pads its input deal with this problem.

For `colight`, the graph interface can now load directly from sumo network files. So `colight` can now directly work with `sumo` networks without using converters. In addition, like with `mplight`, it now pads its input to deal with irregular shapes.