### PR TITLE
Fix ppo_pfrl, maddpg_v2 and madg agents

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -7,7 +7,7 @@ from .sotl import SOTLAgent
 from .frap import FRAP_DQNAgent
 from .ppo_pfrl import IPPO_pfrl
 # from .maddpg import MADDPGAgent
-# from .maddpg_v2 import MADDPGAgent
+from .maddpg_v2 import MADDPGAgent
 from .presslight import PressLightAgent
 from .fixedtime import FixedTimeAgent
 from .mplight import MPLightAgent

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -8,6 +8,7 @@ from .frap import FRAP_DQNAgent
 from .ppo_pfrl import IPPO_pfrl
 # from .maddpg import MADDPGAgent
 from .maddpg_v2 import MADDPGAgent
+from .magd import MAGDAgent
 from .presslight import PressLightAgent
 from .fixedtime import FixedTimeAgent
 from .mplight import MPLightAgent

--- a/agent/ppo_pfrl.py
+++ b/agent/ppo_pfrl.py
@@ -42,12 +42,12 @@ class IPPO_pfrl(RLAgent):
         self.sub_agents = 1
         self.rank = rank
         self.device = torch.device('cpu')
-        self.buffer_size = Registry.mapping['trainer_mapping']['trainer_setting'].param['buffer_size']
+        self.buffer_size = Registry.mapping['trainer_mapping']['setting'].param['buffer_size']
         self.replay_buffer = self.replay_buffer = deque(maxlen=self.buffer_size)
 
-        self.phase = Registry.mapping['world_mapping']['traffic_setting'].param['phase']
-        self.one_hot = Registry.mapping['world_mapping']['traffic_setting'].param['one_hot']
-        self.model_dict = Registry.mapping['model_mapping']['model_setting'].param
+        self.phase = Registry.mapping['model_mapping']['setting'].param['phase']
+        self.one_hot = Registry.mapping['model_mapping']['setting'].param['one_hot']
+        self.model_dict = Registry.mapping['model_mapping']['setting'].param
 
         # get generator for each DQNAgent
         inter_id = self.world.intersection_ids[self.rank]
@@ -60,7 +60,7 @@ class IPPO_pfrl(RLAgent):
                                                      in_only=True, average='all', negative=True)
         self.action_space = gym.spaces.Discrete(len(self.world.id2intersection[inter_id].phases))
 
-        self.learning_rate = Registry.mapping['model_mapping']['model_setting'].param['learning_rate']
+        self.learning_rate = Registry.mapping['model_mapping']['setting'].param['learning_rate']
 
         if self.phase:
             if self.one_hot:
@@ -74,8 +74,8 @@ class IPPO_pfrl(RLAgent):
         self.optimizer = None
         self._build_model()
 
-    def __repr__():
-        return self.model
+    def __repr__(self):
+        return self.model.__repr__()
 
     def reset(self):
         inter_id = self.world.intersection_ids[self.rank]
@@ -202,7 +202,7 @@ class IPPO_pfrl(RLAgent):
         self.model.load_state_dict(torch.load(model_name))
 
     def save_model(self, e):
-        path = os.path.join(Registry.mapping['logger_mapping']['output_path'].path, 'model')
+        path = os.path.join(Registry.mapping['logger_mapping']['path'].path, 'model')
         if not os.path.exists(path):
             os.makedirs(path)
         model_name = os.path.join(path, f'{e}_{self.rank}.pt')

--- a/configs/tsc/maddpg_v2.yml
+++ b/configs/tsc/maddpg_v2.yml
@@ -5,6 +5,7 @@ includes:
 model:
   name: maddpg_v2
   local_q_learn: False
+  train_model: True
   graphic: False
   vehicle_max: 1
   alpha: 0.01

--- a/configs/tsc/ppo_pfrl.yml
+++ b/configs/tsc/ppo_pfrl.yml
@@ -4,6 +4,7 @@ includes:
 
 model:
   name: ppo_pfrl
+  train_model: True
   graphic: False
   vehicle_max: 1
   learning_rate: 0.0001


### PR DESCRIPTION
This PR partially fixes #15.

`ppo_pfrl` runs now. I believe the registry mapping changed was changed after the `ppo_pfrl.py` was pushed, which is why it wasn't working. Modifying the registry mappings to what is followed now fixed the problem.

`maddpg_v2` runs now. It has a similiar issue like `ppo_pfrl` but it had an additional problem where the replay buffer where storing action states taken rather than the action probabilities. Changing it to store action probabilities led the code to work.

`madg` needed no modification. Importing it in agent/__init__.py made it work.

`maddpg` was not fixed. It seems that the code was incomplete. Since there is a version 2 of this algorithm implemented, I left it as it is.

Note that, I tested the code that it worked for both SUMO and CityFlow. I did not test it till convergence, since it takes a long time for the policy based algorithms. But I think it should work as I made no major modifications to the code itself.