### PR TITLE
Fixed a bug when minimum yellow phase duration is fractional

### DIFF
--- a/world/world_sumo.py
+++ b/world/world_sumo.py
@@ -240,7 +240,7 @@ class Intersection(object):
         # TODO: check if change state, yellow phase must less than minimum of action time
         # test yellow finished first
         self.virtual_phase = action
-        if self.current_phase_time == self.yellow_phase_time:
+        if self.current_phase_time >= self.yellow_phase_time:
             self._change_phase(action)
         else:
             if action != self.get_current_phase() and self.current_phase_time > self.yellow_phase_time:


### PR DESCRIPTION
In some networks, the `yellow_phase_time` duration is fractional (i.e. 1.5 s, 2.5 s, 4.5 s etc.). In such networks, this piece of code never runs for managing changing phases in intersections:

```
if self.current_phase_time == self.yellow_phase_time:
            self._change_phase(action)
```

So when running any RL model with one-hot encoding, it eventually faces an `IndexError` and crashes. This simple fix should fix the problem.